### PR TITLE
Ignore primary and foreign key constraints

### DIFF
--- a/convert_ondemand/convert_ondemand.py
+++ b/convert_ondemand/convert_ondemand.py
@@ -46,7 +46,9 @@ class scraper:
 		soup = BeautifulSoup.BeautifulSoup(open(self.filePath).read(), "html.parser")
 		# Find SQL statement
 		try:
-			return soup.find("pre").text
+			query = soup.find("pre").text
+			# Temporary fix to eliminate foreign and primary key contstraints before inserting data
+			return re.sub('((,FOREIGN KEY)|(,PRIMARY KEY)).*','',query)
 		except AttributeError:
 			return None
 


### PR DESCRIPTION
Removed lines containing PRIMARY KEY or FOREIGN KEY from the query before execution, since the tables are currently loaded in an arbitrary order that does not take these criteria into consideration, and some exports may also violate the PRIMARY KEY constraint.
